### PR TITLE
Replace hatchling with setuptools in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,5 @@ Documentation = "https://github.com/mpeirone/zabbix-mcp-server#readme"
 zabbix-mcp = "src.zabbix_mcp_server:main"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src"]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Update the pyproject.toml file by replacing hatchling with setuptools to enable installation via: pip3 install git+https://github.com/mpeirone/zabbix-mcp-server.git