### PR TITLE
Added ability to get AuditLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ A comprehensive Model Context Protocol (MCP) server for Zabbix integration using
 - `configuration_import` - Import configurations
 - `apiinfo_version` - Get API version information
 
+### Auditlog Management
+- `auditlog_get` - Retrieve auditlog with date and limit filters
+
 ## Installation
 
 ### Prerequisites

--- a/scripts/test_server.py
+++ b/scripts/test_server.py
@@ -158,6 +158,14 @@ def test_basic_operations() -> bool:
             print(f"    ✅ Retrieved {len(items)} item(s)")
         else:
             print("    ⚠️  No items found (this might be normal)")
+
+        # Test auditlogs
+        print("  - Testing item retrieval...")
+        auditlogs = client.auditlog.get(limit=5)
+        if auditlogs:
+            print(f"    ✅ Retrieved {len(items)} auditlog(s)", auditlogs)
+        else:
+            print("    ⚠️  No items found (this might be normal)")
         
         print("✅ Basic operations successful")
         return True

--- a/scripts/test_server.py
+++ b/scripts/test_server.py
@@ -161,9 +161,9 @@ def test_basic_operations() -> bool:
 
         # Test auditlogs
         print("  - Testing item retrieval...")
-        auditlogs = client.auditlog.get(limit=5)
+        auditlogs = client.auditlog.get(limit=1)
         if auditlogs:
-            print(f"    ✅ Retrieved {len(items)} auditlog(s)", auditlogs)
+            print(f"    ✅ Retrieved {len(items)} auditlog(s)")
         else:
             print("    ⚠️  No items found (this might be normal)")
         

--- a/src/zabbix_mcp_server.py
+++ b/src/zabbix_mcp_server.py
@@ -1523,6 +1523,34 @@ def get_transport_config() -> Dict[str, Any]:
     
     return config
 
+# AUDIT LOG MANAGEMENT
+@mcp.tool()
+def auditlog_get(time_from: Optional[int] = None,
+              time_till: Optional[int] = None,
+              limit: Optional[int] = None) -> str:
+    """Get auditlog from Zabbix.
+
+    Args:
+        auditids: List of item IDs to get trends for
+        time_from: Start time (Unix timestamp)
+        time_till: End time (Unix timestamp)
+        limit: Maximum number of results
+
+    Returns:
+        str: JSON formatted auditlog
+    """
+    client = get_zabbix_client()
+    params = {}
+
+    if time_from:
+        params["time_from"] = time_from
+    if time_till:
+        params["time_till"] = time_till
+    if limit:
+        params["limit"] = limit
+
+    result = client.auditlog.get(**params)
+    return format_response(result)
 
 def main():
     """Main entry point for uv execution."""


### PR DESCRIPTION
Added ability to retrieve auditlog based on time (to and from) as well as limit.

Unit testing:
<img width="1124" height="392" alt="Screenshot 2025-12-03 at 11 48 31 AM" src="https://github.com/user-attachments/assets/f19164b0-d090-4fc9-a2c6-97d1041e7595" />

Testing with real Zabbix server through Claude Desktop:
<img width="616" height="1145" alt="Screenshot 2025-12-03 at 11 49 24 AM" src="https://github.com/user-attachments/assets/c094727e-1feb-4140-b9f3-42daef167276" />
