### PR TITLE
improved host_get tools and added two new tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive Model Context Protocol (MCP) server for Zabbix integration using
 - `host_create` - Create new hosts with interfaces and templates
 - `host_update` - Update existing host configurations
 - `host_delete` - Remove hosts from monitoring
+- `hostinterfaces_get` - Retrieve host interfaces with advanced filtering
 
 ### 👥 Host Group Management
 - `hostgroup_get` - Retrieve host groups
@@ -28,6 +29,7 @@ A comprehensive Model Context Protocol (MCP) server for Zabbix integration using
 - `item_create` - Create new monitoring items
 - `item_update` - Update existing items
 - `item_delete` - Remove monitoring items
+- `item_get_current_status` - Get current status and last value of monitoring items
 
 ### ⚠️ Trigger Management
 - `trigger_get` - Retrieve triggers and alerts

--- a/src/helpers/fastmcp_patch.py
+++ b/src/helpers/fastmcp_patch.py
@@ -1,0 +1,58 @@
+"""
+Runtime patch to make FastMCP tolerant to unknown tool arguments (e.g., toolCallId from some clients).
+
+This patches fastmcp.tools.tool.FunctionTool.run to drop any keys not present in the
+underlying function's signature before FastMCP/Pydantic validation runs. This prevents
+ValidationError: unexpected keyword argument <name> while keeping strict typing for known args.
+
+Safe to import multiple times; the patch will simply overwrite the method once.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Dict
+
+try:
+    from fastmcp.tools.tool import FunctionTool  # type: ignore
+except Exception as e:  # pragma: no cover - defensive: FastMCP not installed/changed API
+    raise RuntimeError("Failed to import FunctionTool from fastmcp; API may have changed.") from e
+
+log = logging.getLogger("zammad_mcp.arg_sanitizer")
+
+# Keep a reference to the original implementation
+_original_run = getattr(FunctionTool, "run", None)
+
+if _original_run is None:
+    raise RuntimeError("fastmcp.tools.tool.FunctionTool.run was not found; incompatible FastMCP version?")
+
+
+async def _run_with_arg_sanitizer(self: FunctionTool, arguments: Dict[str, Any]) -> Any:  # type: ignore[override]
+    """Sanitize tool arguments before invoking FastMCP's validator.
+
+    - Only strips keys not in the wrapped function's signature.
+    - Leaves non-dict payloads untouched (delegate to original).
+    - Caches allowed parameter names per instance for performance.
+    """
+    # If the payload isn't a mapping, delegate unchanged
+    if not isinstance(arguments, dict):
+        return await _original_run(self, arguments)  # type: ignore[misc]
+
+    # Build and cache the whitelist of valid parameter names
+    if not hasattr(self, "_allowed_parameter_names"):
+        signature = inspect.signature(self.fn)
+        self._allowed_parameter_names = tuple(signature.parameters.keys())  # type: ignore[attr-defined]
+
+    allowed = getattr(self, "_allowed_parameter_names")  # type: ignore[attr-defined]
+    sanitized = {k: v for k, v in arguments.items() if k in allowed}
+
+    if len(sanitized) != len(arguments):
+        removed = sorted(set(arguments.keys()) - set(allowed))
+        tool_name = getattr(self, "name", getattr(self.fn, "__name__", "<unknown>"))
+        log.debug("Dropped unsupported fields for tool '%s': %s", tool_name, removed)
+
+    return await _original_run(self, sanitized)  # type: ignore[misc]
+
+
+# Apply the monkey patch
+FunctionTool.run = _run_with_arg_sanitizer  # type: ignore[assignment]

--- a/src/zabbix_mcp_server.py
+++ b/src/zabbix_mcp_server.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Union
 from fastmcp import FastMCP
 from zabbix_utils import ZabbixAPI
 from dotenv import load_dotenv
+from helpers import fastmcp_patch
 
 # Load environment variables from .env file
 load_dotenv()


### PR DESCRIPTION
Hey there,
I've added these changes just for my own use in order to make our AI agent more effective for our own purposes. I've offered this pull request in case you are interested in any of these changes for the overall zabbix-mcp-server project. I did not, however add these changes with other people in mind so it's completely fine if you reject this. The changes I introduced are:

- added optional severity filter to the host_get function which allows the AI agent to filter only for hosts with problems that have a given severity
- added hostinterfaces_get tool which returns the hostinterfaces for a given set of host ids. The hostinterface includes some information which we would like our AI agent to be able to look up (which it cant as things were before) like Server IP, DNS name and port and also allows it to filter by these categories
- get_item_current_status: this is an extension of the item.get method but just trimmed to only return the current status of an item allowing an AI to look up things like storage use percentages or similar easily and quickly and we hope reduces problems or difficulty for AI interaction and may allow it to be more effective with each tool call as doing this for an AI just from scratch with the item.get function is a lot to ask for

If these changes seem interesting to you and you feel like they should be incorporated into the original repository then this can gladly be done. If you think that this is not helpful or adds unnecessary bloat for too many people then I'll just keep my version and you can reject this pull request. In any case, I wish you a wonderful day and thank you for maintaining this repo.