### PR TITLE
fix(zabbix_api): support positional (array) params for *.delete methods

### DIFF
--- a/src/zabbix_mcp_server/server.py
+++ b/src/zabbix_mcp_server/server.py
@@ -12,7 +12,7 @@ License: GPL-3.0-or-later
 
 import logging
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from fastmcp import FastMCP
 from .api_docs_scraper import scrape_zabbix_api, get_method_docs
 from starlette.requests import Request
@@ -81,7 +81,7 @@ def _get_api_objects() -> Dict[str, list[str]]:
 
 @mcp.tool()
 @_with_server_url
-def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
+def zabbix_api(method: str, params: Optional[Union[Dict[str, Any], List[Any]]] = None) -> str:
     """Execute Zabbix API method.
 
     This is the main tool for interacting with Zabbix. It requires multiple
@@ -139,7 +139,7 @@ def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
     if params is None:
         params = {}
 
-    if method.endswith(".get") and "output" not in params:
+    if isinstance(params, dict) and method.endswith(".get") and "output" not in params:
         params = {**params, "output": ["name"]}
         logger.debug(f"Applied default output=['name'] for {method}")
 
@@ -156,7 +156,9 @@ def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
     api_method = getattr(api_obj, api_action)
 
     try:
-        if params:
+        if isinstance(params, list):
+            result = api_method(*params)
+        elif params:
             result = api_method(**params)
         else:
             result = api_method()


### PR DESCRIPTION
## Problem
The generic `zabbix_api(method, params)` tool types `params` as `Optional[Dict[str, Any]]` and invokes `api_method(**params)` (keyword unpacking). Zabbix `*.delete` methods (`item.delete`, `trigger.delete`, `host.delete`, `template.delete`, `usermacro.delete`, …) take a **root-level array of IDs** passed as **positional** arguments, e.g. `item.delete("123", "456")`. A bare array cannot be expressed via `**dict`, so these methods are currently **uncallable** through the tool (Zabbix returns `Invalid parameter "/1": a number is expected`).

## Fix (minimal)
- `params` accepts `Union[Dict[str, Any], List[Any]]`.
- Invocation branches on type: `list` → `api_method(*params)` (positional); `dict` → `api_method(**params)` (unchanged); else no-arg.
- The `.get` default-output block is guarded with `isinstance(params, dict)` so it is skipped for list params.

## Non-regression
- Object-param methods (`*.get`, `*.create`, `*.update`, `host.massadd`, …) unchanged.
- READ_ONLY gating unchanged (`delete` still blocked in read-only mode).
- FastMCP derives the tool schema from the annotation, so `params` becomes `anyOf: [object, array]` automatically.

## Example now possible
`zabbix_api('item.delete', ['79298', '79299'])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)