### PR TITLE
fix: accept a JSON-encoded string for the zabbix_api params argument

### DIFF
--- a/src/zabbix_mcp_server/server.py
+++ b/src/zabbix_mcp_server/server.py
@@ -10,9 +10,10 @@ Author: Zabbix MCP Server Contributors
 License: GPL-3.0-or-later
 """
 
+import json
 import logging
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from fastmcp import FastMCP
 from .api_docs_scraper import scrape_zabbix_api, get_method_docs
 from starlette.requests import Request
@@ -81,7 +82,7 @@ def _get_api_objects() -> Dict[str, list[str]]:
 
 @mcp.tool()
 @_with_server_url
-def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
+def zabbix_api(method: str, params: Optional[Union[Dict[str, Any], str]] = None) -> str:
     """Execute Zabbix API method.
 
     This is the main tool for interacting with Zabbix. It requires multiple
@@ -135,6 +136,11 @@ def zabbix_api(method: str, params: Optional[Dict[str, Any]] = None) -> str:
         )
 
     client = get_zabbix_client()
+
+    # Depending on how an MCP client marshals tool arguments, params may arrive as a
+    # JSON-encoded string rather than an object; decode it so such calls validate.
+    if isinstance(params, str):
+        params = json.loads(params) if params.strip() else None
 
     if params is None:
         params = {}


### PR DESCRIPTION
## Problem

The `zabbix_api` tool types its `params` argument as `Optional[Dict[str, Any]]`. FastMCP/pydantic validates tool-call arguments at the boundary, so if `params` arrives as a JSON-encoded string rather than an object, validation fails with a `dict_type` error before the function body runs. Depending on how an MCP client marshals tool-call arguments, the object can arrive as such a string, which makes every call that passes `params` fail.

## Fix

Accept `Optional[Union[Dict[str, Any], str]]` and decode a string value with `json.loads()` at the start of the body. Calls that already pass an object are unaffected.

```python
if isinstance(params, str):
    params = json.loads(params) if params.strip() else None
```

## Testing

- `python -m py_compile` passes.
- Coercion verified for a JSON-encoded object string, a dict, `None`, and an empty/whitespace string.
